### PR TITLE
Fixed lambda to support pointer return types

### DIFF
--- a/fn/lambda.c
+++ b/fn/lambda.c
@@ -1,6 +1,17 @@
 macro lambda {
   case {
     match {
+      $(args) -> $(ret list) $(body)
+    }
+    template {
+      $(@getsym lambda 0)
+    }
+    toplevel {
+      $(@splice ret) $(@gensym lambda) $(args) $(body)
+    }
+  }
+  case {
+    match {
       $(args) -> $(ret) $(body)
     }
     template {


### PR DESCRIPTION
Hey, I was doing some project and was using your lib for it. Figured out it doesn't support following:
lambda (int, int) -> **char*** {}

The bolded part (return type) in this case where I use a pointer wouldn't expand correctly since it would treat char and * as separate tokens. Also using parens around is not possible. So I did the changes to support it correctly.

Now the following:
lambda (int, int) -> (char*) {}
expands to:
char* lambdaxxx (int, int) {}

Cheers,
Vanja